### PR TITLE
wellbeing: Disable activatable on disabled screen time row

### DIFF
--- a/panels/wellbeing/cc-wellbeing-panel.ui
+++ b/panels/wellbeing/cc-wellbeing-panel.ui
@@ -68,6 +68,8 @@
                 </child>
                 <child>
                   <object class="AdwPreferencesRow" id="screen_time_statistics_disabled_row">
+                    <property name="activatable">False</property>
+                    <property name="focusable">False</property>
                     <child>
                       <object class="AdwStatusPage">
                         <!-- Ensure the box is tall enough to show the AdwStatusPage without making it scrollable -->


### PR DESCRIPTION
The row is currently activatable, while activating the row doesn't do anything.

This commit disables activatable so there isn't any confusion.